### PR TITLE
run_all_create_season_layerdata_files.m: update koenig example with p…

### DIFF
--- a/cresis-toolbox/+imb/run_all_create_season_layerdata_files.m
+++ b/cresis-toolbox/+imb/run_all_create_season_layerdata_files.m
@@ -55,21 +55,14 @@ else
   keyboard
   layer_params = struct('name','surface');
   layer_params.source = 'layerdata';
-  layer_params(1).layerdata_source = 'layerData_koenig';
+  layer_params(1).layerdata_source = 'layer_koenig';
   layer_params(2).existence_check = true;
   layer_params(1).fix_broken_layerdata = true; % Found some bad files
   layer_params(2).name = 'bottom';
   layer_params(2).source = 'layerdata';
-  layer_params(2).layerdata_source = 'layerData_koenig';
+  layer_params(2).layerdata_source = 'layer_koenig';
   layer_params(2).existence_check = false;
   layer_params(2).fix_broken_layerdata = true; % Found some bad files
-  for lay_idx=2:30
-    layer_params(lay_idx+1).name = sprintf('Koenig_%d',lay_idx);
-    layer_params(lay_idx+1).source = 'layerdata';
-    layer_params(lay_idx+1).layerdata_source = 'layerData_koenig';
-    layer_params(lay_idx+1).existence_check = false;
-    layer_params(lay_idx+1).fix_broken_layerdata = true; % Found some bad files
-  end
 end
 
 param_override = [];

--- a/cresis-toolbox/processing/collate_coh_noise.m
+++ b/cresis-toolbox/processing/collate_coh_noise.m
@@ -346,10 +346,10 @@ for img = param.collate_coh_noise.imgs
             end
             B = tukeywin(round(1/(fcutoff*dgps_time)/2)*2+1,0.5).';
             B = B / sum(B);
-            firdec_noise(bin_idx,:) = nan_fir_dec(coh_bin,B,dx);
+            firdec_noise(bin_idx,:) = interp_finite(nan_fir_dec(coh_bin,B,dx),0);
           end
           %firdec_noise(bin_idx,isnan(firdec_noise(bin_idx,:))) = 0;
-          noise_est = interp_finite(interp1(firdec_gps_time,firdec_noise(bin_idx,:),noise.gps_time),0);
+          noise_est = interp1(firdec_gps_time,firdec_noise(bin_idx,:),noise.gps_time);
           coh_bin = coh_bin - noise_est;
         end
         if enable_cn_plot
@@ -561,10 +561,15 @@ for img = param.collate_coh_noise.imgs
     end
     
     if enable_visible_plot
+      % frm_id
+      fprintf('\nDebug breakpoint:\n  frm_id is a useful variable that maps the block to the frame that the block occurs in.\n\n');
+      [~,frm_id] = get_frame_id(param,noise.gps_time);
+
       % Bring plots to front
       for h_fig_idx = 1:length(h_fig)
         figure(h_fig(h_fig_idx));
       end
+      
       % Enter debug mode
       keyboard
     end


### PR DESCRIPTION
…roper paths

collate_coh_noise: fix fir_dec interpolation so it is done over the entire segment instead of a small block of data, add frm_id debug variable