### PR TITLE
combine_passes: handle overlapped frames

### DIFF
--- a/cresis-toolbox/+multipass/multipass.m
+++ b/cresis-toolbox/+multipass/multipass.m
@@ -127,6 +127,7 @@ if ~isfield(param.multipass,'pass_en_mask') || isempty(param.multipass.pass_en_m
 end
 % Assume any undefined passes are enabled
 param.multipass.pass_en_mask(end+1:length(pass)) = true;
+param.multipass.pass_en_mask = logical(param.multipass.pass_en_mask);
 pass_en_mask = param.multipass.pass_en_mask;
 if ~pass_en_mask(master_idx)
   error('The master index pass %d must be enabled in param.multipass.pass_en_mask.', master_idx);
@@ -308,6 +309,9 @@ if enable_debug_plot
   legend(h_plot_map,h_legend_map);
   legend(h_plot_elev,h_legend_elev);
   h_axes_echo = h_axes_echo(pass_en_mask);
+  % x-axes from each pass do not line up since the images are not
+  % registered yet so this does not really work in the x-axis unless the
+  % along-track sampling rate is similar between each pass
   linkaxes(h_axes_echo);
   xlim(h_axes_echo(1),[1 max_rlines]);
   ylim(h_axes_echo(1),param.multipass.time_gate*1e6);
@@ -621,7 +625,6 @@ for pass_out_idx = 1:length(pass_en_idxs)
       set(gca,'YDir','normal');
       
       % Convert layerPnts_y from TWTT to WGS_84 Elevation
-      elevation = pass(master_idx).elev;
       surface = pass(pass_idx).layers(1).twtt_ref;
       for lay_idx = 1:length(pass(pass_idx).layers)
         layer_y_curUnit = pass(pass_idx).layers(lay_idx).twtt_ref;
@@ -642,7 +645,7 @@ for pass_out_idx = 1:length(pass_en_idxs)
       xlabel('Range line');
     end
     colormap(1-gray(256));
-    title(sprintf('%s_%03d %d',pass(pass_idx).param_sar.day_seg,pass(pass_idx).param_pass.cmd.frms(1),pass(pass_idx).direction),'interpreter','none')
+    title(sprintf('%s_%03d %d',pass(pass_idx).param_pass.day_seg,pass(pass_idx).param_pass.cmd.frms(1),pass(pass_idx).direction),'interpreter','none')
     %caxis([-90 8]);
     
   else

--- a/cresis-toolbox/+multipass/run_combine_passes.m
+++ b/cresis-toolbox/+multipass/run_combine_passes.m
@@ -180,9 +180,9 @@ if strcmpi(example_str,'Ryder_line1_2011_2013_2015_2019')
   %% Ryder line1 2011,2013,2015,2019
   pass_name = sprintf('Ryder_line1_2011_2013_2015_2019');
   dist_min = 16000;
-  master_pass_idx = 2;
+  master_pass_idx = 3; % Use 2015 since it runs parallel to glacier
   start = struct('lat',81.537723,'lon',-50.392724);
-  stop = struct('lat',81.907007,'lon',-50.980905);
+  stop = struct('lat',81.800,'lon',-50.669);
   input_type = 'echo';
   passes = struct('day_seg',{},'frms',{},'param_fn',{},'in_path',{});
   
@@ -198,13 +198,13 @@ if strcmpi(example_str,'Ryder_line1_2011_2013_2015_2019')
   
   param_fn = 'rds_param_2015_Greenland_C130.xls';
   day_seg = '20150506_02';
-  frms = 20;
+  frms = 19:20;
   passes(end+1) = struct('day_seg',day_seg,'frms',frms,'param_fn',param_fn,'in_path','CSARP_post/standard');
   
-%   param_fn = 'rds_param_2019_Greenland_P3.xls';
-%   day_seg = '20190423_01';
-%   frms = 15:16;
-%   passes(end+1) = struct('day_seg',day_seg,'frms',frms,'param_fn',param_fn,'in_path','standard');
+  param_fn = 'rds_param_2019_Greenland_P3.xls';
+  day_seg = '20190423_01';
+  frms = 15:16;
+  passes(end+1) = struct('day_seg',day_seg,'frms',frms,'param_fn',param_fn,'in_path','standard');
 end
 
 if strcmpi(example_str,'Steensby_line1_2011_2013_2015_2019')

--- a/cresis-toolbox/+multipass/run_multipass.m
+++ b/cresis-toolbox/+multipass/run_multipass.m
@@ -116,18 +116,19 @@ end
 
 if strcmpi(example_str,'Ryder_line1_2011_2013_2015_2019')
   %% Ryder Line 1 2011, 2013, 2015, 2019
-  param.multipass.fn = fullfile(gRadar.out_path,'rds','2014_Greenland_P3','CSARP_multipass','Ryder_line1_2011_2013_2015_2019');
+  param.multipass.fn = fullfile(gRadar.out_path,'rds','2015_Greenland_C130','CSARP_multipass','Ryder_line1_2011_2013_2015_2019');
   
   param.multipass.rbins = [];
   
-  param.multipass.baseline_master_idx = 2;
-  param.multipass.master_idx = 2;
+  % Use 2015 for master_idx since it runs parallel to glacier
+  param.multipass.baseline_master_idx = 3;
+  param.multipass.master_idx = 3;
   
   param.multipass.pass_en_mask = [];
   param.multipass.output_fn_midfix = [];
   param.multipass.coregistration_time_shift = [0 0 0 0];
   param.multipass.comp_mode = 2;
-  param.multipass.time_gate = [2e-6 13e-6];
+  param.multipass.time_gate = [2e-6 15e-6];
 end
 
 if strcmpi(example_str,'Steensby_line1_2011_2013_2015_2019')

--- a/cresis-toolbox/matlab_speed_test.m
+++ b/cresis-toolbox/matlab_speed_test.m
@@ -43,7 +43,7 @@ end
 %% GPU Section
 if 1
   % gpuDeviceTable
-  for gpu_idx = 1:gpuDeviceCount('available')
+  for gpu_idx = 1:gpuDeviceCount
     gpu_dev = gpuDevice(gpu_idx);
     % 8 bytes per sample, 3 copies in memory, 10e3 rows, 80% utilization
     cols = min(10e3,floor(gpu_dev.TotalMemory / 10e3 / 8 / 3 * 0.8));

--- a/cresis-toolbox/posting/load_L1B.m
+++ b/cresis-toolbox/posting/load_L1B.m
@@ -349,3 +349,12 @@ if ~isfield(mdata,'Heading') && isfield(mdata,'GPS_time')
   mdata.Heading = nan(size(mdata.GPS_time));
 end
 
+%% Time, Depth field correction for old files
+if size(mdata.Time,1) == 1 && size(mdata.Time,2) > 1
+  warning('mdata.Time is a row vector and should always be a column vector. Fixing.');
+  mdata.Time = mdata.Time.';
+end
+if isfield(mdata,'Depth')
+  warning('Old file format. mdata.Depth is deprecated. Removing field.');
+  mdata = rmfield(mdata,'Depth');
+end


### PR DESCRIPTION
multipass: force pass_en_mask to be logical to fix bug when "1" double is passed in instead of logical, fix title in final debug figures
run_combine_passes: fix Ryder settings to use best master pass, remove part of flightlines that diverge too much from each other, include missing frame
run_multipass: fix Ryder settings to use best master pass, improve time gate to not clip twtt
matlab_speed_test.m: removed available argument from gpuDeviceCount because it caused failures on machines with no GPUs
load_L1B: correct row Time field, remove Depth field