### PR TITLE
Fix coherent noise problem that exposed the fact that Tsys was not

### DIFF
--- a/cresis-toolbox/processing/analysis_task.m
+++ b/cresis-toolbox/processing/analysis_task.m
@@ -527,7 +527,10 @@ for img = 1:length(store_param.load.imgs)
         DDC_freq_min = [];
         DDC_freq_max = [];
         
-        % Pulse compression
+        % Pulse compression (special settings for coherent noise)
+        if strcmp(radar_type,'deramp')
+          tmp_param.radar.wfs(wf).Tsys(:) = 0;
+        end
         tmp_param.radar.wfs(wf).coh_noise_method = '';
         tmp_param.radar.wfs(wf).deconv.en = false;
         tmp_param.radar.wfs(wf).nz_trim = {};

--- a/cresis-toolbox/processing/array_task.m
+++ b/cresis-toolbox/processing/array_task.m
@@ -183,7 +183,7 @@ for img = 1:length(param.array.imgs)
               if dTsys ~= 0
                 % Positive dTsys means Tsys > Tsys_old and we should reduce the
                 % time delay to all targets by dTsys.
-                sar_data.(data_field_name) = ifft(bsxfun(@times,fft(sar_data.(data_field_name)),exp(1i*2*pi*sar_data.wfs(wf).freq*dTsys)));
+                sar_data.(data_field_name) = ifft(bsxfun(@times,fft(sar_data.(data_field_name),[],1),exp(1i*2*pi*sar_data.wfs(wf).freq*dTsys)),[],1);
               end
               
               % Concatenate data (resample in fast-time if needed since
@@ -266,7 +266,7 @@ for img = 1:length(param.array.imgs)
           if dTsys ~= 0
             % Positive dTsys means Tsys > Tsys_old and we should reduce the
             % time delay to all targets by dTsys.
-            sar_data.(data_field_name) = ifft(bsxfun(@times,fft(sar_data.(data_field_name)),exp(1i*2*pi*sar_data.wfs(wf).freq*dTsys)));
+            sar_data.(data_field_name) = ifft(bsxfun(@times,fft(sar_data.(data_field_name),[],1),exp(1i*2*pi*sar_data.wfs(wf).freq*dTsys)),[],1);
           end
           
           % Concatenate data (handle situation of time axis of previous
@@ -331,7 +331,7 @@ for img = 1:length(param.array.imgs)
               if dTsys ~= 0
                 % Positive dTsys means Tsys > Tsys_old and we should reduce the
                 % time delay to all targets by dTsys.
-                sar_data.(data_field_name) = ifft(bsxfun(@times,fft(sar_data.(data_field_name)),exp(1i*2*pi*sar_data.wfs(wf).freq*dTsys)));
+                sar_data.(data_field_name) = ifft(bsxfun(@times,fft(sar_data.(data_field_name),[],1),exp(1i*2*pi*sar_data.wfs(wf).freq*dTsys)),[],1);
               end
               
               % Concatenate data (resample in fast-time if needed since


### PR DESCRIPTION
applied for deramp radars during data_pulse_compress.m. Now
analysis_task.m coherent noise command forces Tsys to zero for deramp
systems so that coherent noise removal always happens with Tsys=0 data
for deramp systems. The Tsys is then applied for deramp after pulse
compression in data_pulse_compress.m.

Minor update to array_task.m, fft dimension for applying Tsys is now
forced to be done on the first/row-dimension.