### PR TITLE
Fix new layer creation broken in newer versions of Matlab

### DIFF
--- a/cresis-toolbox/+imb/@echowin/layerCM_callback.m
+++ b/cresis-toolbox/+imb/@echowin/layerCM_callback.m
@@ -252,6 +252,8 @@ elseif source == obj.left_panel.layerCM_new || source == obj.left_panel.layerCM_
         end
       end
     end
+  else
+    error('Create new layer in OPS via the prefs window.');
   end
   
 elseif source == obj.left_panel.layerCM_edit

--- a/cresis-toolbox/+imb/@prefwin/layers_callback.m
+++ b/cresis-toolbox/+imb/@prefwin/layers_callback.m
@@ -1,6 +1,10 @@
 function layers_callback(obj,status,event)
 
 h_status = get(status);
+if isfield(h_status,'Text')
+  % Handle missing label field in newer versions of Matlab (R2017b+)
+  h_status.Label = h_status.Text;
+end
 if isfield(h_status,'Label') && strcmp(get(status,'Label'),'New')
   h_fig = figure('NumberTitle','off','Name','New Layer','DockControls','off','NumberTitle','off','ToolBar','none','MenuBar','none');
   pos = get(h_fig,'Position');


### PR DESCRIPTION
The Label field was deprecated and replaced by Text in R2017b. This caused new layer creation in the picker to fail silently. 